### PR TITLE
Another apple scroll fix

### DIFF
--- a/src/components/BottomNavigationBar/BottomNavigationBar.js
+++ b/src/components/BottomNavigationBar/BottomNavigationBar.js
@@ -1,38 +1,46 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import styles from './BottomNavigationBar.module.scss';
 import { NavLink, useRouteMatch } from 'react-router-dom';
 import { t } from '../../utils/translate';
 import Icons from '../../assets/Icons';
 import PropTypes from 'prop-types';
 
-const BottomNavigationBar = () => (
-  <div className={styles.bottomNavigationBar}>
-    <ButtonLink label={t('TABS.home')} to="/main">
-      {!useRouteMatch({ path: '/main', exact: true }) ? (
-        <Icons.home />
-      ) : (
-        <Icons.homeFilled />
-      )}
-    </ButtonLink>
-    <ButtonLink label={t('TABS.discover')} to="/main/discover">
-      {!useRouteMatch('/main/discover') ? (
-        <Icons.discover />
-      ) : (
-        <Icons.discoverFilled />
-      )}
-    </ButtonLink>
-    <ButtonLink label={t('TABS.chat')} to="/main/chat">
-      {!useRouteMatch('/main/chat') ? <Icons.chat /> : <Icons.chatFilled />}
-    </ButtonLink>
-    <ButtonLink label={t('TABS.profile')} to="/main/profile">
-      {!useRouteMatch('/main/profile') ? (
-        <Icons.profile />
-      ) : (
-        <Icons.profileFilled />
-      )}
-    </ButtonLink>
-  </div>
-);
+const BottomNavigationBar = () => {
+  const bottomNav = useRef(null);
+  useEffect(() => {
+    bottomNav.current.addEventListener('touchmove', e => {
+      e.preventDefault();
+    });
+  }, []);
+  return (
+    <div className={styles.bottomNavigationBar} ref={bottomNav}>
+      <ButtonLink label={t('TABS.home')} to="/main">
+        {!useRouteMatch({ path: '/main', exact: true }) ? (
+          <Icons.home />
+        ) : (
+          <Icons.homeFilled />
+        )}
+      </ButtonLink>
+      <ButtonLink label={t('TABS.discover')} to="/main/discover">
+        {!useRouteMatch('/main/discover') ? (
+          <Icons.discover />
+        ) : (
+          <Icons.discoverFilled />
+        )}
+      </ButtonLink>
+      <ButtonLink label={t('TABS.chat')} to="/main/chat">
+        {!useRouteMatch('/main/chat') ? <Icons.chat /> : <Icons.chatFilled />}
+      </ButtonLink>
+      <ButtonLink label={t('TABS.profile')} to="/main/profile">
+        {!useRouteMatch('/main/profile') ? (
+          <Icons.profile />
+        ) : (
+          <Icons.profileFilled />
+        )}
+      </ButtonLink>
+    </div>
+  );
+};
 
 const ButtonLink = ({ label, to, children }) => {
   return (

--- a/src/components/BottomNavigationBar/BottomNavigationBar.js
+++ b/src/components/BottomNavigationBar/BottomNavigationBar.js
@@ -5,36 +5,34 @@ import { t } from '../../utils/translate';
 import Icons from '../../assets/Icons';
 import PropTypes from 'prop-types';
 
-const BottomNavigationBar = () => {
-  return (
-    <div className={styles.bottomNavigationBar}>
-      <ButtonLink label={t('TABS.home')} to="/main">
-        {!useRouteMatch({ path: '/main', exact: true }) ? (
-          <Icons.home />
-        ) : (
-          <Icons.homeFilled />
-        )}
-      </ButtonLink>
-      <ButtonLink label={t('TABS.discover')} to="/main/discover">
-        {!useRouteMatch('/main/discover') ? (
-          <Icons.discover />
-        ) : (
-          <Icons.discoverFilled />
-        )}
-      </ButtonLink>
-      <ButtonLink label={t('TABS.chat')} to="/main/chat">
-        {!useRouteMatch('/main/chat') ? <Icons.chat /> : <Icons.chatFilled />}
-      </ButtonLink>
-      <ButtonLink label={t('TABS.profile')} to="/main/profile">
-        {!useRouteMatch('/main/profile') ? (
-          <Icons.profile />
-        ) : (
-          <Icons.profileFilled />
-        )}
-      </ButtonLink>
-    </div>
-  );
-};
+const BottomNavigationBar = () => (
+  <div className={styles.bottomNavigationBar}>
+    <ButtonLink label={t('TABS.home')} to="/main">
+      {!useRouteMatch({ path: '/main', exact: true }) ? (
+        <Icons.home />
+      ) : (
+        <Icons.homeFilled />
+      )}
+    </ButtonLink>
+    <ButtonLink label={t('TABS.discover')} to="/main/discover">
+      {!useRouteMatch('/main/discover') ? (
+        <Icons.discover />
+      ) : (
+        <Icons.discoverFilled />
+      )}
+    </ButtonLink>
+    <ButtonLink label={t('TABS.chat')} to="/main/chat">
+      {!useRouteMatch('/main/chat') ? <Icons.chat /> : <Icons.chatFilled />}
+    </ButtonLink>
+    <ButtonLink label={t('TABS.profile')} to="/main/profile">
+      {!useRouteMatch('/main/profile') ? (
+        <Icons.profile />
+      ) : (
+        <Icons.profileFilled />
+      )}
+    </ButtonLink>
+  </div>
+);
 
 const ButtonLink = ({ label, to, children }) => {
   return (

--- a/src/components/BottomNavigationBar/BottomNavigationBar.module.scss
+++ b/src/components/BottomNavigationBar/BottomNavigationBar.module.scss
@@ -3,14 +3,10 @@
 .bottomNavigationBar {
   display: flex;
   align-items: center;
+  align-self: stretch;
   justify-content: space-around;
   background-color: $tab-bar-color;
   height: $bottom-nav-height;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 1;
 
   .active {
     p {

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import styles from './Toolbar.module.scss';
 import IconButton from '../IconButton';
 import PropTypes from 'prop-types';
@@ -9,25 +9,33 @@ const Toolbar = ({
   rightIcon,
   onLeftIconClick,
   onRightIconClick,
-}) => (
-  <div className={styles.toolbar}>
-    {leftIcon && (
-      <IconButton
-        icon={leftIcon}
-        onClick={onLeftIconClick}
-        superClass={styles.toolbarIcon}
-      />
-    )}
-    <div className={styles.title}>{title}</div>
-    {rightIcon && (
-      <IconButton
-        icon={rightIcon}
-        onClick={onRightIconClick}
-        superClass={styles.toolbarIcon}
-      />
-    )}
-  </div>
-);
+}) => {
+  const toolbar = useRef(null);
+  useEffect(() => {
+    toolbar.current.addEventListener('touchmove', e => {
+      e.preventDefault();
+    });
+  }, []);
+  return (
+    <div className={styles.toolbar} ref={toolbar}>
+      {leftIcon && (
+        <IconButton
+          icon={leftIcon}
+          onClick={onLeftIconClick}
+          superClass={styles.toolbarIcon}
+        />
+      )}
+      <div className={styles.title}>{title}</div>
+      {rightIcon && (
+        <IconButton
+          icon={rightIcon}
+          onClick={onRightIconClick}
+          superClass={styles.toolbarIcon}
+        />
+      )}
+    </div>
+  );
+};
 
 Toolbar.propTypes = {
   title: PropTypes.string,

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -9,27 +9,25 @@ const Toolbar = ({
   rightIcon,
   onLeftIconClick,
   onRightIconClick,
-}) => {
-  return (
-    <div className={styles.toolbar}>
-      {leftIcon && (
-        <IconButton
-          icon={leftIcon}
-          onClick={onLeftIconClick}
-          superClass={styles.toolbarIcon}
-        />
-      )}
-      <div className={styles.title}>{title}</div>
-      {rightIcon && (
-        <IconButton
-          icon={rightIcon}
-          onClick={onRightIconClick}
-          superClass={styles.toolbarIcon}
-        />
-      )}
-    </div>
-  );
-};
+}) => (
+  <div className={styles.toolbar}>
+    {leftIcon && (
+      <IconButton
+        icon={leftIcon}
+        onClick={onLeftIconClick}
+        superClass={styles.toolbarIcon}
+      />
+    )}
+    <div className={styles.title}>{title}</div>
+    {rightIcon && (
+      <IconButton
+        icon={rightIcon}
+        onClick={onRightIconClick}
+        superClass={styles.toolbarIcon}
+      />
+    )}
+  </div>
+);
 
 Toolbar.propTypes = {
   title: PropTypes.string,

--- a/src/components/Toolbar/Toolbar.module.scss
+++ b/src/components/Toolbar/Toolbar.module.scss
@@ -3,12 +3,9 @@
 .toolbar {
   display: flex;
   align-items: center;
+  align-self: stretch;
   background-color: $main-bg-color;
   height: $toolbar-height;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
 
   .toolbarIcon {
     margin: 0 14px;

--- a/src/hoc/PageContainer/PageContainer.js
+++ b/src/hoc/PageContainer/PageContainer.js
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './PageContainer.module.scss';
 
-const PageContainer = ({ children }) => {
-  const classes = [styles.container];
-  const hasToolbar = children[0].type.name === 'Toolbar';
-  hasToolbar && classes.push(styles.accountForToolbar);
-  return <div className={classes.join(' ')}>{children}</div>;
-};
+const PageContainer = ({ children }) => (
+  <div className={styles.pageContainer}>{children}</div>
+);
 
 PageContainer.propTypes = {
   children: PropTypes.node,

--- a/src/hoc/PageContainer/PageContainer.module.scss
+++ b/src/hoc/PageContainer/PageContainer.module.scss
@@ -8,5 +8,5 @@
   right: 0;
   display: flex;
   flex-direction: column;
-  -webkit-overflow-scrolling: touch;
+  // -webkit-overflow-scrolling: touch;
 }

--- a/src/hoc/PageContainer/PageContainer.module.scss
+++ b/src/hoc/PageContainer/PageContainer.module.scss
@@ -1,9 +1,11 @@
 @import '../../variables.scss';
 
-.container {
-  padding: 0 $screen-margin;
-}
-
-.accountForToolbar {
-  margin-top: $toolbar-height;
+.pageContainer {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/hoc/PageContainer/PageContainer.module.scss
+++ b/src/hoc/PageContainer/PageContainer.module.scss
@@ -8,4 +8,5 @@
   right: 0;
   display: flex;
   flex-direction: column;
+  -webkit-overflow-scrolling: touch;
 }

--- a/src/hoc/ScrollableContent/ScrollableContent.js
+++ b/src/hoc/ScrollableContent/ScrollableContent.js
@@ -1,0 +1,23 @@
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
+import style from './ScrollableContent.module.scss';
+import handleScroll from '../../utils/scrollHandler';
+
+const ScrollableContent = ({ children }) => {
+  const ref = useRef(null);
+  return (
+    <div
+      ref={ref}
+      onScroll={() => handleScroll(ref)}
+      className={style.scrollableContent}
+    >
+      {children}
+    </div>
+  );
+};
+
+ScrollableContent.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default ScrollableContent;

--- a/src/hoc/ScrollableContent/ScrollableContent.module.scss
+++ b/src/hoc/ScrollableContent/ScrollableContent.module.scss
@@ -6,4 +6,5 @@
   flex: 1;
   overflow-y: scroll;
   padding: 0 $screen-margin;
+  -webkit-overflow-scrolling: touch;
 }

--- a/src/hoc/ScrollableContent/ScrollableContent.module.scss
+++ b/src/hoc/ScrollableContent/ScrollableContent.module.scss
@@ -1,0 +1,9 @@
+@import '../../variables.scss';
+
+.scrollableContent {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: scroll;
+  padding: 0 $screen-margin;
+}

--- a/src/hoc/ScrollableContent/index.js
+++ b/src/hoc/ScrollableContent/index.js
@@ -1,0 +1,2 @@
+import ScrollableContent from './ScrollableContent';
+export default ScrollableContent;

--- a/src/hoc/TabContainer/TabContainer.js
+++ b/src/hoc/TabContainer/TabContainer.js
@@ -1,11 +1,18 @@
-import React from 'react';
-import styles from './TabContainer.module.scss';
+import React, { useRef } from 'react';
+import classes from './TabContainer.module.scss';
 import PropTypes from 'prop-types';
+import handleScroll from '../../utils/scrollHandler';
 
 const TabContainer = ({ active, children }) => {
+  const ref = useRef(null);
   const style = active ? { display: 'block' } : { display: 'none' };
   return (
-    <div className={styles.tab} style={style}>
+    <div
+      ref={ref}
+      onScroll={() => handleScroll(ref)}
+      className={classes.tab}
+      style={style}
+    >
       {children}
     </div>
   );

--- a/src/hoc/TabContainer/TabContainer.module.scss
+++ b/src/hoc/TabContainer/TabContainer.module.scss
@@ -1,5 +1,8 @@
 @import '../../variables.scss';
 
 .tab {
-  margin-bottom: $bottom-nav-height;
+  flex: 1;
+  align-self: stretch;
+  overflow-y: scroll;
+  padding: 0 $screen-margin;
 }

--- a/src/hoc/TabContainer/TabContainer.module.scss
+++ b/src/hoc/TabContainer/TabContainer.module.scss
@@ -5,4 +5,5 @@
   align-self: stretch;
   overflow-y: scroll;
   padding: 0 $screen-margin;
+  -webkit-overflow-scrolling: touch;
 }

--- a/src/pages/LoginPage/LoginPage.js
+++ b/src/pages/LoginPage/LoginPage.js
@@ -11,6 +11,7 @@ import Button from '../../components/Button';
 import TextInput from '../../components/TextInput';
 import Toolbar from '../../components/Toolbar';
 import Icons from '../../assets/Icons';
+import ScrollableContent from '../../hoc/ScrollableContent';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -61,34 +62,36 @@ const LoginPage = () => {
         leftIcon="back"
         onLeftIconClick={navigateBack}
       />
-      <section className={styles.logoContainer}>
-        <Icons.peili className={styles.logo} />
-        <h1>Peili</h1>
-      </section>
-      <form className={styles.formSection}>
-        <TextInput
-          type="email"
-          value={email}
-          label={emailLabel}
-          onChange={handleEmailChange}
-          placeholder={emailPlaceholder}
-          errorMessage={emailError}
-        />
-        <TextInput
-          type="password"
-          value={password}
-          label={passwordLabel}
-          style={{ marginTop: '16px' }}
-          onChange={handlePasswordChange}
-          placeholder="••••••••"
-          errorMessage={passwordError}
-        />
-        <Button
-          label={loginLabel}
-          style={{ margin: '32px 0 64px' }}
-          onClick={handleLoginClick}
-        />
-      </form>
+      <ScrollableContent>
+        <section className={styles.logoContainer}>
+          <Icons.peili className={styles.logo} />
+          <h1>Peili</h1>
+        </section>
+        <form className={styles.formSection}>
+          <TextInput
+            type="email"
+            value={email}
+            label={emailLabel}
+            onChange={handleEmailChange}
+            placeholder={emailPlaceholder}
+            errorMessage={emailError}
+          />
+          <TextInput
+            type="password"
+            value={password}
+            label={passwordLabel}
+            style={{ marginTop: '16px' }}
+            onChange={handlePasswordChange}
+            placeholder="••••••••"
+            errorMessage={passwordError}
+          />
+          <Button
+            label={loginLabel}
+            style={{ margin: '32px 0 64px' }}
+            onClick={handleLoginClick}
+          />
+        </form>
+      </ScrollableContent>
     </PageContainer>
   );
 };

--- a/src/pages/MainAppPage/MainAppPage.js
+++ b/src/pages/MainAppPage/MainAppPage.js
@@ -6,6 +6,7 @@ import DiscoverTab from './DiscoverTab';
 import ChatTab from './ChatTab';
 import ProfileTab from './ProfileTab';
 import BottomNavigationBar from '../../components/BottomNavigationBar';
+import Toolbar from '../../components/Toolbar';
 
 const MainAppPage = () => {
   const location = useLocation();
@@ -18,6 +19,7 @@ const MainAppPage = () => {
 
   return (
     <PageContainer>
+      <Toolbar leftIcon="info" title="Test title" />
       <HomeTab visible={homeVisible} />
       <DiscoverTab visible={discoverVisible} />
       <ChatTab visible={chatVisible} />

--- a/src/pages/MainAppPage/MainAppPage.js
+++ b/src/pages/MainAppPage/MainAppPage.js
@@ -6,7 +6,6 @@ import DiscoverTab from './DiscoverTab';
 import ChatTab from './ChatTab';
 import ProfileTab from './ProfileTab';
 import BottomNavigationBar from '../../components/BottomNavigationBar';
-import Toolbar from '../../components/Toolbar';
 
 const MainAppPage = () => {
   const location = useLocation();

--- a/src/pages/MainAppPage/MainAppPage.js
+++ b/src/pages/MainAppPage/MainAppPage.js
@@ -19,7 +19,6 @@ const MainAppPage = () => {
 
   return (
     <PageContainer>
-      <Toolbar leftIcon="info" title="Test title" />
       <HomeTab visible={homeVisible} />
       <DiscoverTab visible={discoverVisible} />
       <ChatTab visible={chatVisible} />

--- a/src/pages/SignupPage/SignupPage.js
+++ b/src/pages/SignupPage/SignupPage.js
@@ -4,6 +4,7 @@ import D from '../../utils/dictionary';
 import { t } from '../../utils/translate';
 
 import PageContainer from '../../hoc/PageContainer';
+import ScrollableContent from '../../hoc/ScrollableContent';
 import Toolbar from '../../components/Toolbar';
 import Text from '../../components/Text';
 
@@ -18,7 +19,9 @@ const SignupPage = () => {
         leftIcon="back"
         onLeftIconClick={handleLeftIconPress}
       />
-      <Text>dis will be signup page</Text>
+      <ScrollableContent>
+        <Text>dis will be signup page</Text>
+      </ScrollableContent>
     </PageContainer>
   );
 };

--- a/src/utils/scrollHandler.js
+++ b/src/utils/scrollHandler.js
@@ -1,0 +1,13 @@
+const handleScroll = container => {
+  const element = container.current;
+  const offsetHeight = element.offsetHeight;
+  const scrollHeight = element.scrollHeight;
+  if (element.scrollTop === 0) {
+    element.scrollTop += 1;
+  }
+  if (element.scrollTop + offsetHeight === scrollHeight) {
+    element.scrollTop -= 1;
+  }
+};
+
+export default handleScroll;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -11,8 +11,8 @@ $card-bg-color: #222326;
 $card-detail-color: #45464c;
 $card-placeholder-color: #505259;
 $error-color: #ff273d;
-$toggle-active-bg-color: #64604B;
-$toggle-color: #D3D3D4;
+$toggle-active-bg-color: #64604b;
+$toggle-color: #d3d3d4;
 
 // Fonts
 $font: 'Catamaran', sans-serif;
@@ -32,4 +32,4 @@ $body-text-size: 18px;
 $screen-margin: 32px;
 $radius-10: 10px;
 $bottom-nav-height: 56px;
-$toolbar-height: 50px;
+$toolbar-height: 56px;


### PR DESCRIPTION
@Nkiuru @samuliv 

Pros and cons from this PR.

**Pros**

* Scrolling works.
* Scrollbar doesn't go over the navigation components.
* Tab scroll position also started to work. No need for custom JavaScript handler.

**Cons**

* You can still fuck up the scroll behaviour if you start the scroll over the **BottomNavigationBar** or **Toolbar**. You could prevent this, but doing so also disables all touches on tab bar and toolbar buttons.
* Browser UI won't hide on down scroll. Although won't be a problem on PWA.

If we decide to use this then the page jsx structure will be following:

```
[SomePage.js]

const SomePage = () => {
  ...
  return (
    <PageContainer>
      <Toolbar />    <-- optional
      <ScrollableContent>
        { content }
      </ScrollableContent>
      <BottomNavigationBar />    <-- optional
    </PageContainer>
  );
};
```

MainAppPage is an exception, we don't have to wrap the tabs in ScrollableContent. The scrolling is handled in each tabs TabContainer already.

```
<PageContainer>
  <HomeTab visible={homeVisible} />
  <DiscoverTab visible={discoverVisible} />
  <ChatTab visible={chatVisible} />
  <ProfileTab visible={profileVisible} />
  <BottomNavigationBar />
</PageContainer>
```